### PR TITLE
feat: support installing `terminus-build-tools-plugin`

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,31 @@ steps:
     runs: terminus site:list
 ```
 
+You can also specify a major version of the
+[`Terminus Build Tools plugin`](https://github.com/pantheon-systems/terminus-build-tools-plugin)
+to install with the `build-tools-plugin` input:
+
+```yaml
+steps:
+  - name: Setup PHP
+    uses: shivammathur/setup-php@v2
+    with:
+      php-version: '7.4'
+
+  - name: Install Terminus
+    uses: pantheon-systems/terminus-github-actions@main
+    with:
+      pantheon-machine-token: ${{ secrets.PANTHEON_MACHINE_TOKEN }}
+      build-tools-plugin: v3 # or v2, if you're using Terminus v2
+
+  - name: List build environments
+    runs: terminus build:env:list
+```
+
+> **Note**
+>
+> `composer` is required to install the build tools for v2
+
 ## Credits
 
 Big thanks to <a href="https://github.com/G-Rath">Gareth Jones</a> and <a href="https://www.ackama.com/">Ackama</a> for the initial development work.

--- a/action.yml
+++ b/action.yml
@@ -11,6 +11,12 @@ inputs:
     description: |
       The full version of Terminus to install. If omitted, the latest version is used.
     required: false
+  build-tools-plugin:
+    description: |
+      The major version of `terminus-build-tools-plugin` to install, if any.
+
+      Should be `v3` for Terminus v3, and `v2` for Terminus v2 - any other values are ignored
+    required: false
 runs:
   using: composite
   steps:
@@ -31,6 +37,19 @@ runs:
         sudo ln -s ~/terminus/terminus /usr/local/bin/terminus
       env:
         TERMINUS_RELEASE: ${{ inputs.terminus-version || env.TERMINUS_RELEASE }}
+
+    - name: Install Terminus Build Tools v3
+      shell: bash
+      if: ${{ inputs.build-tools-plugin == 'v3' }}
+      run: |
+        terminus self:plugin:install terminus-build-tools-plugin
+
+    - name: Install Terminus Build Tools v2
+      shell: bash
+      if: ${{ inputs.build-tools-plugin == 'v2' }}
+      run: |
+        mkdir -p ~/.terminus/plugins
+        composer create-project --no-dev -d ~/.terminus/plugins pantheon-systems/terminus-build-tools-plugin:^2
 
     - name: Login to Pantheon
       shell: bash


### PR DESCRIPTION
This adds support for installing the [`Terminus Build Tools plugin`](https://github.com/pantheon-systems/terminus-build-tools-plugin) as part of setting up Terminus.

I have confirmed that this works by using it on one of our internal projects.