### PR TITLE
Only run login when input is provided.

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -33,6 +33,7 @@ runs:
         TERMINUS_RELEASE: ${{ inputs.terminus-version || env.TERMINUS_RELEASE }}
 
     - name: Login to Pantheon
+      if: ${{ inputs.pantheon-machine-token }}
       shell: bash
       run: |
         terminus auth:login --machine-token="${{ inputs.pantheon-machine-token }}"

--- a/action.yml
+++ b/action.yml
@@ -6,7 +6,7 @@ branding:
 inputs:
   pantheon-machine-token:
     description: "Machine token used to authenticate with Pantheon."
-    required: true
+    required: false
   terminus-version:
     description: |
       The full version of Terminus to install. If omitted, the latest version is used.


### PR DESCRIPTION
Currently login causes a failure when a Pantheon token is not supplied. Although it is 'required' in the inputs, Github does not currently have any checks for when a required input is not supplied.