### PR TITLE
Add Pantheon to Github Action name.

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -1,4 +1,4 @@
-name: Setup Terminus
+name: Setup Pantheon Terminus
 description: "Install and configure the Pantheon CLI tool, Terminus."
 branding:
   icon: "cloud"


### PR DESCRIPTION
Since Pantheon now has an official Action for setting up Terminus, it is recommended that I deprecate my Action and Pantheon take the name in the Marketplace (to avoid developer confusion). 

This will update the name in the Marketplace, making it more discoverable by people searching for Pantheon Terminus.

Please note this change first requires removing my Action from the Marketplace, so it will need to be done in conjunction with approval.

0. Approve change.
1. Remove Setup Pantheon Terminus (kopepasah)  from Actions Marketplace.
2. Merge change.

- https://github.com/kopepasah/setup-pantheon-terminus
- https://github.com/marketplace/actions/setup-pantheon-terminus