### PR TITLE
feat: authenticate API requests with `GITHUB_TOKEN` to avoid rate-limit

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -18,7 +18,12 @@ runs:
       shell: bash
       if: ${{ ! inputs.terminus-version }}
       run: |
-        TERMINUS_RELEASE=$(curl --silent "https://api.github.com/repos/pantheon-systems/terminus/releases/latest" | perl -nle'print $& while m#"tag_name": "\K[^"]*#g')
+        TERMINUS_RELEASE=$(
+          curl --silent \
+            --header 'authorization: Bearer ${{ github.token }}' \
+            "https://api.github.com/repos/pantheon-systems/terminus/releases/latest" \
+            | perl -nle'print $& while m#"tag_name": "\K[^"]*#g'
+        )
         echo "TERMINUS_RELEASE=$TERMINUS_RELEASE" >> $GITHUB_ENV
 
     - name: Install Terminus


### PR DESCRIPTION
GH limits unauthenticated API requests to 60 an hour - GHA can authenticate using `github.token` which is always present to raise the limit to 1000 per hour.

Note that the GH API is only used for determining the latest version of Terminus so anyone specifying a specific version will not be rate limited, since the release download endpoint is not subject to rate limiting.