### PR TITLE
fix: update action name

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -1,4 +1,4 @@
-name: Setup Pantheon Terminus
+name: Setup Terminus
 description: "Install and configure the Pantheon CLI tool, Terminus."
 branding:
   icon: "cloud"


### PR DESCRIPTION
@namespacebrian I'm pretty sure this should fix the problem you described [here](https://github.com/pantheon-systems/terminus-github-actions/pull/12#issuecomment-1380965633) - this is the name that the action is published as on the marketplace, and I'm guessing it doesn't like the current name because of [this old action](https://github.com/kopepasah/setup-pantheon-terminus) even though that's been delisted.