### PR TITLE
docs: use `run` instead of `runs` on README

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ steps:
       pantheon-machine-token: ${{ secrets.PANTHEON_MACHINE_TOKEN }}
 
   - name: List sites
-    runs: terminus site:list
+    run: terminus site:list
 ```
 
 By default, this action installs the latest version of Terminus that has been
@@ -45,7 +45,7 @@ steps:
       terminus-version: 2.6.5
 
   - name: List sites
-    runs: terminus site:list
+    run: terminus site:list
 ```
 
 ## Credits


### PR DESCRIPTION
In the current README sample code, "every step must define a `uses` or `run` key" occurs in the last step.