### PR TITLE
Avoid Auth0 rate limiting by reusing Terminus session

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -40,7 +40,7 @@ runs:
     - name: Login to Pantheon by restoring existing Terminus session or initiating new
       if: ${{ inputs.pantheon-machine-token }}
       shell: bash
-      uses: lullabot/terminus-auth-with-session-cache@v2
+      uses: lullabot/terminus-auth-with-session-cache@v3
       with:
         pantheon-machine-token: ${{ secrets.PANTHEON_MACHINE_TOKEN }}
         # Set 'ddev: true' if using DDEV in GitHub Actions.

--- a/action.yml
+++ b/action.yml
@@ -37,8 +37,11 @@ runs:
       env:
         TERMINUS_RELEASE: ${{ inputs.terminus-version || env.TERMINUS_RELEASE }}
 
-    - name: Login to Pantheon
+    - name: Login to Pantheon by restoring existing Terminus session or initiating new
       if: ${{ inputs.pantheon-machine-token }}
       shell: bash
-      run: |
-        terminus auth:login --machine-token="${{ inputs.pantheon-machine-token }}"
+      uses: lullabot/terminus-auth-with-session-cache@v2
+      with:
+        pantheon-machine-token: ${{ secrets.PANTHEON_MACHINE_TOKEN }}
+        # Set 'ddev: true' if using DDEV in GitHub Actions.
+        # ddev: true


### PR DESCRIPTION
Related Pantheon docs page: https://docs.pantheon.io/terminus/ci/github-actions

PR for the docs page: https://github.com/pantheon-systems/documentation/pull/8666

Ideally, we would love to transfer the [terminus-auth-with-session-cache](https://github.com/Lullabot/terminus-auth-with-session-cache) action from the Lullabot GitHub org to Pantheon's. Let me know if that's desired/possible!