### PR TITLE
Don't save the cache if cache is disabled

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -108,7 +108,7 @@ runs:
 
     - name: Cache encrypted Terminus session
       id: save-cache
-      if: ${{ steps.authenticate.outcome == 'success' }}
+      if: ${{ steps.authenticate.outcome == 'success' && inputs.disable-cache != 'true'}}
       uses: actions/cache/save@v4
       with:
         path: ${{ steps.configure-cache.outputs.path }}


### PR DESCRIPTION
Currently, the disable-cache option only affects the loading of the cache. The cache is still saved, regardless of the user's preference. This PR changes that, so disable-cache will also disable the saving of the cache.