### PR TITLE
Owner suggestion for catalog-info.yml

### DIFF
--- a/catalog-info.yml
+++ b/catalog-info.yml
@@ -9,4 +9,4 @@ metadata:
 spec:
   type: tool
   lifecycle: mature
-  owner: devx
+  owner: pantheon-systems/devx


### PR DESCRIPTION
The pattern I see around is `company-github-name/department-or-team`, so 'devx' would be `pantheon-systems/devx`.