### PR TITLE
Fix faulty error output on empty cache

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -84,7 +84,7 @@ runs:
         TERMINUS_USER=$(terminus auth:whoami)
 
         if [ -z "$TERMINUS_USER" ]; then
-          # No user, skip step to continue to authenticate.
+          echo "No valid session found. "
           exit 0
         fi
 

--- a/action.yml
+++ b/action.yml
@@ -71,6 +71,9 @@ runs:
       if: ${{ steps.restore-cache.outcome == 'success' }}
       shell: bash
       run: |
+        # Default to no session.
+        echo "session_found=false" >> $GITHUB_OUTPUT
+
         # Verify that the encrypted session file was restored from cache.
         if [ ! -s "${{ steps.configure-cache.outputs.path }}" ]; then
           echo "No session file found in cache."
@@ -91,10 +94,11 @@ runs:
         fi
 
         echo "Valid session found: $TERMINUS_USER"
+        echo "session_found=true" >> $GITHUB_OUTPUT
 
     - name: Authenticate Terminus
       id: authenticate
-      if: ${{ inputs.pantheon-machine-token && steps.decrypt.outcome != 'success' }}
+      if: ${{ inputs.pantheon-machine-token && steps.decrypt.outputs.session_found != 'true' }}
       shell: bash
       run: |
 

--- a/action.yml
+++ b/action.yml
@@ -84,15 +84,15 @@ runs:
         TERMINUS_USER=$(terminus auth:whoami)
 
         if [ -z "$TERMINUS_USER" ]; then
-          echo "No valid session found. "
-          exit 1
+          # No user, skip step to continue to authenticate.
+          exit 0
         fi
 
         echo "Valid session found: $TERMINUS_USER"
 
     - name: Authenticate Terminus
       id: authenticate
-      if: ${{ inputs.pantheon-machine-token && steps.decrypt.outcome != 'success' }}
+      if: ${{ inputs.pantheon-machine-token && steps.decrypt.outcome != 'skipped' }}
       shell: bash
       run: |
 

--- a/action.yml
+++ b/action.yml
@@ -69,20 +69,22 @@ runs:
     - name: Decrypt cached session file
       id: decrypt
       if: ${{ steps.restore-cache.outcome == 'success' }}
-      continue-on-error: true
       shell: bash
       run: |
-
         # Verify that the encrypted session file was restored from cache.
-        test -s ${{ steps.configure-cache.outputs.path }}
+        if [ ! -s "${{ steps.configure-cache.outputs.path }}" ]; then
+          echo "No session file found in cache."
+          exit 0
+        fi
 
         # Decrypt the session file.
         echo "${{ inputs.pantheon-machine-token }}" | \
         openssl enc -d -aes-256-cbc -pbkdf2 -iter 10000 -pass stdin -in ${{ steps.configure-cache.outputs.path }} -out $HOME/.terminus/cache/session
 
-        # Check if restored session is still valid
-        TERMINUS_USER=$(terminus auth:whoami)
+        # Check for restored user (string) or allow command to fail gracefully.
+        TERMINUS_USER=$(terminus auth:whoami || true)
 
+        # Check TERMINUS_USER for string.
         if [ -z "$TERMINUS_USER" ]; then
           echo "No valid session found. "
           exit 0
@@ -92,7 +94,7 @@ runs:
 
     - name: Authenticate Terminus
       id: authenticate
-      if: ${{ inputs.pantheon-machine-token && steps.decrypt.outcome != 'skipped' }}
+      if: ${{ inputs.pantheon-machine-token && steps.decrypt.outcome != 'success' }}
       shell: bash
       run: |
 


### PR DESCRIPTION
When there's no existing cache, we skip the step with an `exit 1`, but that also produces an error output for the step. Instead, this will exit gracefully (`exit 0`) by skipping the step and continuing to the next step to authenticate.

fixes #29