### PR TITLE
Update action cache version

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -60,7 +60,7 @@ runs:
     - name: Restore cached encrypted Terminus session
       id: restore-cache
       if: ${{ inputs.disable-cache != 'true' }}
-      uses: actions/cache/restore@v4
+      uses: actions/cache/restore@668228422ae6a00e4ad889ee87cd7109ec5666a7 #v5.0.4
       with:
         path: ${{ steps.configure-cache.outputs.path }}
         key: ${{ steps.configure-cache.outputs.key }}
@@ -120,7 +120,7 @@ runs:
     - name: Cache encrypted Terminus session
       id: save-cache
       if: ${{ steps.authenticate.outcome == 'success' && inputs.disable-cache != 'true'}}
-      uses: actions/cache/save@v4
+      uses: actions/cache/save@668228422ae6a00e4ad889ee87cd7109ec5666a7 #v5.0.4
       with:
         path: ${{ steps.configure-cache.outputs.path }}
         key: ${{ steps.configure-cache.outputs.key }}


### PR DESCRIPTION
We're updating our actions and this is the last one that still displays for us during our Github Action runs.

```text
node.js 20 actions are deprecated. The following actions are running on Node.js 20 and may not work as expected: actions/cache/restore@v4. Actions will be forced to run with Node.js 24 by default starting June 2nd, 2026. Node.js 20 will be removed from the runner on September 16th, 2026. Please check if updated versions of these actions are available that support Node.js 24. To opt into Node.js 24 now, set the FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true environment variable on the runner or in your workflow file. Once Node.js 24 becomes the default, you can temporarily opt out by setting ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION=true. For more information see: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/
```

Our shop has us updating to the sha for security purposes so that is the decision here.  I add the version number as an inline comment.  Please note that this will need to be updated in 6 months or so when https://github.blog/news-insights/product-news/whats-coming-to-our-github-actions-2026-security-roadmap/ dependencies are fully rolled out. 

## Screenshot of deprecations
<img width="753" height="1387" alt="Screenshot 2026-04-02 at 6 58 09 AM" src="https://github.com/user-attachments/assets/c86a36e8-f439-4fa7-b50e-3370448cac8c" />
