### PR TITLE
ci: bump actions off deprecated Node 20 runtime

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      github-actions:
+        patterns:
+          - "*"

--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -11,7 +11,7 @@ jobs:
   tag-release:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - uses: pantheon-systems/action-autotag@v0
         with:
           gh-token: ${{ github.token }}

--- a/.github/workflows/test-terminus-version.yml
+++ b/.github/workflows/test-terminus-version.yml
@@ -18,7 +18,7 @@ jobs:
     name: ${{ inputs.terminus-version }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2

--- a/.github/workflows/test-terminus.yml
+++ b/.github/workflows/test-terminus.yml
@@ -11,7 +11,7 @@ jobs:
     name: Terminus Setup
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Setup Terminus
         uses: ./
@@ -27,7 +27,7 @@ jobs:
     name: Terminus Login
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Setup Terminus
         uses: ./


### PR DESCRIPTION
Actions bumped:
- actions/checkout: v4 → v6.0.3

Dependabot config created with github-actions ecosystem coverage (weekly updates, grouped).

🤖